### PR TITLE
Enhance admin dashboard with statistics

### DIFF
--- a/Wombat.Common/Models/DashboardVM.cs
+++ b/Wombat.Common/Models/DashboardVM.cs
@@ -57,5 +57,14 @@ namespace Wombat.Common.Models
 
         public string UserName { get; set; }
         public CoordinatorDashboardVM Coordinator { get; set; }
+
+        // Administrator statistics
+        public int NumberOfInstitutions { get; set; }
+        public int NumberOfSpecialities { get; set; }
+        public int NumberOfSubSpecialities { get; set; }
+        public int NumberOfAssessmentForms { get; set; }
+        public int NumberOfEPAs { get; set; }
+        public int NumberOfUsers { get; set; }
+        public int NumberOfInvitations { get; set; }
     }
 }

--- a/Wombat.Web/Controllers/HomeController.cs
+++ b/Wombat.Web/Controllers/HomeController.cs
@@ -38,31 +38,40 @@ namespace Wombat.Controllers
         private readonly UserManager<WombatUser> userManager;
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly ISubSpecialityRepository subSpecialityRepository;
+        private readonly ISpecialityRepository specialityRepository;
         private readonly IInstitutionRepository institutionRepository;
+        private readonly IAssessmentFormRepository assessmentFormRepository;
         private readonly IEPARepository EPARepository;
         private readonly IAssessmentRequestRepository assessmentRequestRepository;
         private readonly ILoggedAssessmentRepository loggedAssessmentRepository;
+        private readonly IRegistrationInvitationRepository registrationInvitationRepository;
         private readonly IMapper mapper;
 
         public HomeController( UserManager<WombatUser> userManager,
                                IHttpContextAccessor httpContextAccessor,
                                ISubSpecialityRepository subSpecialityRepository,
+                               ISpecialityRepository specialityRepository,
                                ILogger<HomeController> logger,
                                IMapper mapper,
                                IInstitutionRepository institutionRepository,
+                               IAssessmentFormRepository assessmentFormRepository,
                                IEPARepository EPARepository,
                                IAssessmentRequestRepository assessmentRequestRepository,
-                               ILoggedAssessmentRepository loggedAssessmentRepository )
+                               ILoggedAssessmentRepository loggedAssessmentRepository,
+                               IRegistrationInvitationRepository registrationInvitationRepository )
         {
             this.userManager = userManager;
             this.httpContextAccessor = httpContextAccessor;
             this.subSpecialityRepository = subSpecialityRepository;
+            this.specialityRepository = specialityRepository;
             this.mapper = mapper;
             _logger = logger;
             this.institutionRepository = institutionRepository;
+            this.assessmentFormRepository = assessmentFormRepository;
             this.EPARepository = EPARepository;
             this.assessmentRequestRepository = assessmentRequestRepository;
             this.loggedAssessmentRepository = loggedAssessmentRepository;
+            this.registrationInvitationRepository = registrationInvitationRepository;
         }
 
         private int GetMonthsInTraining(DateTime startDate)
@@ -237,6 +246,16 @@ namespace Wombat.Controllers
 
                 var completedAssessments = await assessmentRequestRepository.GetAssessorCompletedAssessments(userId);
                 dashboard.NumberOfCompletedAssessments = completedAssessments?.Count ?? 0;
+            }
+            else if (roles.Contains(Roles.Administrator))
+            {
+                dashboard.NumberOfInstitutions = (await institutionRepository.GetAllAsync())?.Count ?? 0;
+                dashboard.NumberOfSpecialities = (await specialityRepository.GetAllAsync())?.Count ?? 0;
+                dashboard.NumberOfSubSpecialities = (await subSpecialityRepository.GetAllAsync())?.Count ?? 0;
+                dashboard.NumberOfAssessmentForms = (await assessmentFormRepository.GetAllAsync())?.Count ?? 0;
+                dashboard.NumberOfEPAs = (await EPARepository.GetAllAsync())?.Count ?? 0;
+                dashboard.NumberOfUsers = userManager.Users.Count();
+                dashboard.NumberOfInvitations = (await registrationInvitationRepository.GetAllAsync())?.Count ?? 0;
             }
 
             dashboard.User.Institution = mapper.Map<InstitutionVM>(await institutionRepository.GetAsync(user.InstitutionId));               

--- a/Wombat.Web/Views/Home/Index.cshtml
+++ b/Wombat.Web/Views/Home/Index.cshtml
@@ -114,4 +114,74 @@ else if (User.IsInRole(Roles.Coordinator))
             </div>
         </div>
     </div>
+    <div class="row mt-4">
+        <div class="col-md-4 mb-4">
+            <div class="card border-left-primary shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Institutions</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">@Model.NumberOfInstitutions</div>
+                </div>
+                <div class="card-footer bg-transparent text-end">
+                    <a asp-controller="Institutions" asp-action="Index" class="btn btn-sm btn-primary">Manage</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-4">
+            <div class="card border-left-secondary shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-secondary text-uppercase mb-1">Specialities</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">@Model.NumberOfSpecialities</div>
+                </div>
+                <div class="card-footer bg-transparent text-end">
+                    <a asp-controller="Specialities" asp-action="Index" class="btn btn-sm btn-secondary">Manage</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-4">
+            <div class="card border-left-info shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Users</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">@Model.NumberOfUsers</div>
+                </div>
+                <div class="card-footer bg-transparent text-end">
+                    <a asp-controller="WombatUsers" asp-action="Index" class="btn btn-sm btn-info">Manage</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row mb-4">
+        <div class="col-md-4 mb-4">
+            <div class="card border-left-warning shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">Assessment Forms</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">@Model.NumberOfAssessmentForms</div>
+                </div>
+                <div class="card-footer bg-transparent text-end">
+                    <a asp-controller="AssessmentForms" asp-action="Index" class="btn btn-sm btn-warning">Manage</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-4">
+            <div class="card border-left-success shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-success text-uppercase mb-1">EPAs</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">@Model.NumberOfEPAs</div>
+                </div>
+                <div class="card-footer bg-transparent text-end">
+                    <a asp-controller="EPAs" asp-action="Index" class="btn btn-sm btn-success">Manage</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-4">
+            <div class="card border-left-dark shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="text-xs font-weight-bold text-dark text-uppercase mb-1">Invitations</div>
+                    <div class="h5 mb-0 font-weight-bold text-gray-800">@Model.NumberOfInvitations</div>
+                </div>
+                <div class="card-footer bg-transparent text-end">
+                    <a asp-controller="RegistrationInvitations" asp-action="Index" class="btn btn-sm btn-dark">Manage</a>
+                </div>
+            </div>
+        </div>
+    </div>
 }


### PR DESCRIPTION
## Summary
- extend `DashboardVM` with administrator statistics
- inject new repositories into `HomeController`
- compute admin stats in `IndexAsync`
- show new stats cards on the admin homepage

## Testing
- `dotnet build Wombat.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456ae185ec83248aa55f1de1c535d9