### PR TITLE
Refactor SubSpeciality pages

### DIFF
--- a/Wombat.Web/Views/SubSpecialities/Create.cshtml
+++ b/Wombat.Web/Views/SubSpecialities/Create.cshtml
@@ -1,34 +1,39 @@
-﻿@model SubSpecialityVM
+@model SubSpecialityVM
 
 @{
-    ViewData["Title"] = "Create";
+    ViewData["Title"] = "Create Subspeciality";
 }
 
-<h1>Create a subspeciality</h1>
+<div class="container mt-4">
+    <div class="card shadow">
+        <div class="card-header bg-success text-white">
+            <h4 class="mb-0">Add a New Subspeciality</h4>
+        </div>
+        <div class="card-body">
+            <form asp-action="Create">
+                <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
-<hr />
-<div class="row">
-    <div class="col-md-4">
-        <form asp-action="Create">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Name" class="control-label"></label>
-                <input asp-for="Name" class="form-control" />
-                <span asp-validation-for="Name" class="text-danger"></span>
-            </div>
-            <br/>
-            <div class="form-group">
-                <label asp-for="Speciality" class="control-label"></label>
-                <select asp-for="SpecialityId" class ="form-control" asp-items="ViewBag.SpecialityId"></select>
-            </div>
-            <br/>
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label fw-semibold"></label>
+                    <input asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
 
-            <div class="form-group">
-                <a asp-action="Index" class="btn btn-dark">Back to List</a> &nbsp;
-                @* <button id="addRow" type="button" class="btn btn-info">Add Option</button> &nbsp; *@
-                <input type="submit" value="Create" class="btn btn-primary" />
-            </div>
-        </form>
+                <div class="mb-3">
+                    <label asp-for="SpecialityId" class="form-label fw-semibold">Speciality</label>
+                    <select asp-for="SpecialityId" class="form-select" asp-items="ViewBag.SpecialityId"></select>
+                    <span asp-validation-for="SpecialityId" class="text-danger"></span>
+                </div>
+
+                <div class="d-flex justify-content-between">
+                    <a asp-action="Index" class="btn btn-dark">
+                        <i class="fas fa-arrow-left"></i> Back to List
+                    </a>
+                    <button type="submit" class="btn btn-success">
+                        <i class="fas fa-plus-circle"></i> Create
+                    </button>
+                </div>
+            </form>
+        </div>
     </div>
 </div>
-

--- a/Wombat.Web/Views/SubSpecialities/Details.cshtml
+++ b/Wombat.Web/Views/SubSpecialities/Details.cshtml
@@ -1,30 +1,37 @@
-﻿@model SubSpecialityVM
+@model SubSpecialityVM
 
 @{
-    ViewData["Title"] = "Details";
+    ViewData["Title"] = "Subspeciality Details";
 }
 
-<h1>Details</h1>
-
-<div>
-    <h4>SubSpeciality</h4>
-    <hr />
-    <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Name)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Name)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Speciality)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Speciality.Name)
-        </dd>
-    </dl>
-</div>
-<div>
-    <a asp-action="Index" class="btn btn-dark">Back to List</a> &nbsp;
-    <a asp-action="Edit" asp-route-id="@Model?.Id" class="btn btn-warning">Edit</a>
+<div class="container mt-4">
+    <div class="card shadow">
+        <div class="card-header bg-info text-white">
+            <h4 class="mb-0">Subspeciality Details</h4>
+        </div>
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-3 fw-semibold">
+                    @Html.DisplayNameFor(model => model.Name)
+                </dt>
+                <dd class="col-sm-9">
+                    @Html.DisplayFor(model => model.Name)
+                </dd>
+                <dt class="col-sm-3 fw-semibold">
+                    @Html.DisplayNameFor(model => model.Speciality)
+                </dt>
+                <dd class="col-sm-9">
+                    @Html.DisplayFor(model => model.Speciality.Name)
+                </dd>
+            </dl>
+        </div>
+        <div class="card-footer bg-light d-flex justify-content-between">
+            <a asp-action="Index" class="btn btn-dark">
+                <i class="fas fa-arrow-left"></i> Back to List
+            </a>
+            <a asp-action="Edit" asp-route-id="@Model?.Id" class="btn btn-warning">
+                <i class="fas fa-pencil-alt"></i> Edit
+            </a>
+        </div>
+    </div>
 </div>

--- a/Wombat.Web/Views/SubSpecialities/Edit.cshtml
+++ b/Wombat.Web/Views/SubSpecialities/Edit.cshtml
@@ -1,36 +1,41 @@
-﻿@model SubSpecialityVM
+@model SubSpecialityVM
 
 @{
-    ViewData["Title"] = "Edit";
+    ViewData["Title"] = "Edit Subspeciality";
 }
 
-<h1>Edit subspeciality</h1>
-<hr />
-<div class="row">
-    <div class="col-md-4">
-        <form asp-action="Edit">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Name" class="control-label"></label>
-                <input asp-for="Name" class="form-control" />
-                <span asp-validation-for="Name" class="text-danger"></span>
-            </div>
-            <br/>
+<div class="container mt-4">
+    <div class="card shadow">
+        <div class="card-header bg-warning text-dark">
+            <h4 class="mb-0">Edit Subspeciality</h4>
+        </div>
+        <div class="card-body">
+            <form asp-action="Edit">
+                <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
-            <div class="form-group">
-                <label asp-for="Speciality" class="control-label"></label>
-                <select asp-for="SpecialityId" class="form-control" asp-items="ViewBag.SpecialityId"></select>
-                <span asp-validation-for="SpecialityId" class="text-danger"></span>
-            </div>
-            <br />
-            <input type="hidden" asp-for="Id" />
-           
-            <div class="form-group">
-                <a asp-action="Index" class="btn btn-dark">Back to List</a> &nbsp;
-                @* <button id="addRow" type="button" class="btn btn-info">Add Option</button> &nbsp; *@
-                <input type="submit" value="Save Changes" class="btn btn-warning" />
-            </div>
-        </form>
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label fw-semibold"></label>
+                    <input asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SpecialityId" class="form-label fw-semibold">Speciality</label>
+                    <select asp-for="SpecialityId" class="form-select" asp-items="ViewBag.SpecialityId"></select>
+                    <span asp-validation-for="SpecialityId" class="text-danger"></span>
+                </div>
+
+                <input type="hidden" asp-for="Id" />
+
+                <div class="d-flex justify-content-between">
+                    <a asp-action="Index" class="btn btn-dark">
+                        <i class="fas fa-arrow-left"></i> Back to List
+                    </a>
+                    <button type="submit" class="btn btn-warning">
+                        <i class="fas fa-save"></i> Save Changes
+                    </button>
+                </div>
+            </form>
+        </div>
     </div>
 </div>
-

--- a/Wombat.Web/Views/SubSpecialities/Index.cshtml
+++ b/Wombat.Web/Views/SubSpecialities/Index.cshtml
@@ -1,75 +1,74 @@
-﻿@model IEnumerable<SubSpecialityVM>
+@model IEnumerable<SubSpecialityVM>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "Subspecialities";
 }
 
-<h1>Subspecialities</h1>
-
-<p>
-    <a class="btn btn-success" asp-action="Create"><i class="fas fa-plus"></i> Create New</a>
-</p>
-
-<div class="row">
-    <div class="col-md-12">
-        <table class="table" style="width: 100%">
-            <thead>
-                <tr>
-                    <th>
-                        @Html.DisplayNameFor(model => model.Name)
-                    </th>
-                    <th>
-                        @Html.DisplayNameFor(model => model.Speciality)
-                    </th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var item in Model)
-                {
-                    <tr>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.Name)
-                        </td>
-                        <td>
-                             @Html.DisplayFor(modelItem => item.Speciality.Name)
-                        </td>
-                        <td>
-                            <a class="btn btn-warning" asp-action="Edit" asp-route-id="@item.Id"><i class="fas fa-pencil-alt"></i></a>
-                            <a class="btn btn-info" asp-action="Details" asp-route-id="@item.Id"><i class="fas fa-info-circle"></i></a>
-                            <button data-id="@item.Id" class="btn btn-danger deleteBtn" type="button"><i class="far fa-trash-alt"></i></button>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="mb-0">Subspecialities</h2>
+        <a class="btn btn-success" asp-action="Create">
+            <i class="fas fa-plus"></i> Create New
+        </a>
     </div>
+
+    @if (!Model.Any())
+    {
+        <div class="alert alert-info">
+            No subspecialities have been added yet.
+        </div>
+    }
+    else
+    {
+        <div class="card shadow">
+            <div class="card-body p-4">
+                <table id="subSpecialityTable" class="table table-bordered table-hover align-middle mb-0" style="width:100%">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>Speciality</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model)
+                        {
+                            <tr>
+                                <td>@Html.DisplayFor(modelItem => item.Name)</td>
+                                <td>@Html.DisplayFor(modelItem => item.Speciality.Name)</td>
+                                <td class="text-end text-nowrap">
+                                    <div class="btn-group" role="group">
+                                        <a class="btn btn-warning btn-sm" asp-action="Edit" asp-route-id="@item.Id" title="Edit">
+                                            <i class="fas fa-pencil-alt"></i>
+                                        </a>
+                                        <a class="btn btn-info btn-sm" asp-action="Details" asp-route-id="@item.Id" title="Details">
+                                            <i class="fas fa-info-circle"></i>
+                                        </a>
+                                        @if (item.CanEditAndDelete)
+                                        {
+                                            <button type="button"
+                                                    data-id="@item.Id"
+                                                    class="btn btn-danger btn-sm deleteBtn"
+                                                    title="Delete">
+                                                <i class="far fa-trash-alt"></i>
+                                            </button>
+                                        }
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
 </div>
 
-<form id="deleteForm" asp-action="Delete">
-    <input type="hidden" id="ItemId" name="Id" />
+<form id="deleteForm" asp-action="Delete" method="post">
+    <input type="hidden" id="deleteId" name="Id" />
 </form>
 
-@section Scripts {
-    <script>
-        $(function () {
-
-            $('.deleteBtn').click(function (e) {
-                swal({
-                    title: "Are you sure?",
-                    text: "Are you sure you want to delete this record?",
-                    icon: "warning",
-                    buttons: true,
-                    dangerMode: true
-                }).then((confirm) => {
-                    if (confirm) {
-                        var btn = $(this);
-                        var id = btn.data("id");
-                        $("#ItemId").val(id);
-                        $("#deleteForm").submit();
-                    }
-                });
-            });
-        });
-    </script>
+@section Scripts
+{
+    @await Html.PartialAsync("_DeleteConfirmationScript")
 }


### PR DESCRIPTION
## Summary
- restyle the create, details, edit, and index pages for Subspecialities
- use the same card-based bootstrap layout as Institutions

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68457fedd7f883248fd4b8beb4759325