### PR TITLE
Add comment action for assessment requests

### DIFF
--- a/Wombat.Web/Views/AssessmentRequests/Details.cshtml
+++ b/Wombat.Web/Views/AssessmentRequests/Details.cshtml
@@ -1,5 +1,6 @@
 ﻿@model AssessmentRequestVM
 @using Microsoft.AspNetCore.Identity
+@using Wombat.Data
 @inject UserManager<WombatUser> UserManager
 
 @{


### PR DESCRIPTION
## Summary
- allow assessors and trainees to post comments on assessment requests
- ensure comments create AssessmentEvent records and ignore blanks
- include Wombat.Data namespace in Details view for UserManager injection

## Testing
- `dotnet test --verbosity normal`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6897041275dc8324aae910cafcfd8be4